### PR TITLE
Add delete all mode

### DIFF
--- a/background.js
+++ b/background.js
@@ -27,6 +27,10 @@
       chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
         chrome.tabs.sendMessage(tabs[0].id, { tabId: tabs[0].id, ...request });
       });
+    } else if (request.action === 'UPDATE_MODE') {
+      chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        chrome.tabs.sendMessage(tabs[0].id, { tabId: tabs[0].id, ...request });
+      });
     } else {
       console.log('Unknown action requested: ', request.action);
     }

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Shoot the Messenger",
   "description": "This extension sequentially unsends all messenges in a messenger chain.",
-  "version": "6.2.0",
+  "version": "6.3.0",
 
   "content_scripts": [
     {

--- a/popup.html
+++ b/popup.html
@@ -8,6 +8,12 @@
     <input type="number" id="Delay" />
     <div>Start from (exact text to search)</div>
     <input type="text" id="SearchText" />
+    <div>Mode</div>
+    <select id="Mode" name="mode">
+      <option value="default">Default</option>
+      <option value="deleteAll">Delete All</option>
+    </select>
+
     <div id="LastCleared"></div>
     <script
       type="text/javascript"

--- a/popup.js
+++ b/popup.js
@@ -57,3 +57,10 @@ document.getElementById('SearchText').addEventListener('input', (e) => {
     data: e.target.value,
   });
 });
+
+document.getElementById('Mode').addEventListener('input', (e) => {
+  chrome.runtime.sendMessage({
+    action: 'UPDATE_MODE',
+    data: e.target.value,
+  });
+});

--- a/popup.js
+++ b/popup.js
@@ -64,3 +64,19 @@ document.getElementById('Mode').addEventListener('input', (e) => {
     data: e.target.value,
   });
 });
+
+// Send over defaults to clear whatever the prior state is from local storage.
+chrome.runtime.sendMessage({
+  action: 'UPDATE_DELAY',
+  data: document.getElementById('Delay').value,
+});
+
+chrome.runtime.sendMessage({
+  action: 'UPDATE_SEARCH_TEXT',
+  data: document.getElementById('SearchText').value,
+});
+
+chrome.runtime.sendMessage({
+  action: 'UPDATE_MODE',
+  data: document.getElementById('Mode').value,
+});


### PR DESCRIPTION
Does the following:
- adds a mode for delete all. In doing so, refactors the code to have separate logic for 'delete all' and 'delete mine'
- removes the automatic skipping of images, urls, and stickers (seems like these elements can be removed on newer chats, not on older chats)
- adds better handling of default options in the popup.js such that all defaults clear whenever the popup reopens (making the whole thing feel like a single execution to the user, instead of feeling stateful)